### PR TITLE
fix: supporting floats in is_pot

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -820,8 +820,15 @@ def test_minimum_size():
   out_mips = tinybrain.downsample_segmentation(labels, factor=(2,2,1), num_mips=1)
   assert out_mips[0].shape == (50,1,100)  
 
+def test_4x4x4_downsample_segmentation():
+  """Making sure that 4x isotropic downsampling works correctly.
 
+  This is a minimum example for invoking recursive countless3d.
+  """
+  labels = np.ones((4, 4, 4), dtype=np.uint32)
+  assert tinybrain.downsample_segmentation(labels, (4, 4, 4)) == [[[1]]]
 
-
-
-
+def test_float_factor():
+  """Using a float downsampling factor"""
+  labels = np.ones((8, 8, 8), dtype=np.uint32)
+  assert tinybrain.downsample_segmentation(labels, (8., 8., 8.)) == [[[1]]]

--- a/tinybrain/downsample.py
+++ b/tinybrain/downsample.py
@@ -233,7 +233,7 @@ def _downsample_segmentation(data, factor, sparse=False):
   if data.dtype.kind not in ('u', 'i'): # integer types
     return downsample_with_striding(data, tuple(factor))[0]
 
-  is_pot = lambda x: (x != 0) and not (x & (x - 1)) # is power of two
+  is_pot = lambda x: (x > 1) and not (np.log2(x) % 1) # is power of two
   is_twod_pot_downsample = np.any(factor == 1) and is_pot(reduce(operator.mul, factor))
   is_threed_pot_downsample = not np.any(factor == 1) and is_pot(reduce(operator.mul, factor)) 
 


### PR DESCRIPTION
The `_downsample_segmentation` fn has two problems that interact.
1. The lambda function `is_pot` that checks whether a downsampling factors consist of powers of two doesn't support floats since it relies on `bitwise_and`.
```
TypeError: ufunc 'bitwise_and' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```
2. The recursive application of countless turns the factor values into floats by using truediv 
https://github.com/seung-lab/tinybrain/blob/master/tinybrain/downsample.py#L245

This means that even using powers of two that are greater than two fail. For example, a factor of 4 becomes 2.0 and breaks `is_pot`.

There are two ways to fix this:
1. Use floor division in the factor division line. This assumes that your user doesn't want some funkier factor that doesn't evenly divide in two, and it also means that you'll probably want type checks for integer factors somewhere.
2. Let `is_pot` support floats.

I believe this PR accomplishes 2. Let me know what you think.